### PR TITLE
Port into docker, python 3.11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+venv
+*.egg-info
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install ffmpeg -y
+
+COPY . .
+RUN pip install .
+
+ENTRYPOINT [ "/usr/local/bin/subsync" ]

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,33 @@
 from setuptools import setup
 
-exec(open('subsync/version.py').read())
+exec(open("subsync/version.py").read())
 
-setup(name='subsync',
-      version=__version__,
-      description='Synchronize your subtitles with machine learning',
-      classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
-        'Topic :: Multimedia :: Sound/Audio :: Analysis',
-        'Topic :: Multimedia :: Sound/Audio :: Speech',
-      ],
-      keywords='subtitle synchronize machine learning',
-      platforms=["Independent"],
-      scripts=['subsync/bin/subsync'],
-      include_package_data=True,
-      url='https://github.com/tympanix/subsync',
-      author='tympanix',
-      author_email='tympanix@gmail.com',
-      license='MIT',
-      packages=['subsync'],
-      install_requires=[
-          'tensorflow>=1.0.0',
-          'numpy',
-          'matplotlib',
-          'librosa',
-          'h5py>=2.9.0',
-          'pysrt',
-      ],
-      zip_safe=False)
+setup(
+    name="subsync",
+    version=__version__,
+    description="Synchronize your subtitles with machine learning",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Multimedia :: Sound/Audio :: Analysis",
+        "Topic :: Multimedia :: Sound/Audio :: Speech",
+    ],
+    keywords="subtitle synchronize machine learning",
+    platforms=["Independent"],
+    scripts=["subsync/bin/subsync"],
+    include_package_data=True,
+    url="https://github.com/tympanix/subsync",
+    author="tympanix",
+    author_email="tympanix@gmail.com",
+    license="MIT",
+    packages=["subsync"],
+    install_requires=[
+        "tensorflow>=1.0.0",
+        "numpy",
+        "matplotlib",
+        "librosa",
+        "h5py>=2.9.0",
+        "pysrt",
+    ],
+    zip_safe=False,
+)

--- a/subsync/media.py
+++ b/subsync/media.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 
 import numpy as np
 import sklearn
+import sklearn.metrics
 
 from .ffmpeg import Transcode
 from .log import logger
@@ -54,10 +55,16 @@ class Media:
         self.offset = timedelta()
 
     def from_srt(self, filepath):
+        filepath = os.path.abspath(filepath)
         prefix, ext = os.path.splitext(filepath)
         if ext != ".srt":
             raise ValueError("filetype must be .srt format")
-        prefix = os.path.basename(re.sub(r"\.\w\w$", "", prefix))
+        # Strip the following to find prefix:
+        # *.en.srt
+        # *.eng.srt
+        # *.en.forced.srt
+        # *.eng.forced.srt
+        prefix = os.path.basename(re.sub(r"\.\w{2,3}(\.\w+)?$", "", prefix))
         dir = os.path.dirname(filepath)
         for f in os.listdir(dir):
             _, ext = os.path.splitext(f)

--- a/subsync/net.py
+++ b/subsync/net.py
@@ -1,6 +1,8 @@
 import os
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
+
+tf.disable_v2_behavior()
 
 
 class NeuralNet:


### PR DESCRIPTION
Since this project fails to install natively due to https://github.com/tympanix/subsync/issues/29, I took a stab at porting this into a Docker image to freeze a working copy for future use.  As part of this, I upgraded the runtime to python 3.11 which seems to work fine with a couple minor tweaks in this PR.

CI/CD will come in a separate PR.

```bash
docker build -t subsync .

# Assuming /my/media contains both video.mp4 and video.srt
docker run -it --rm -v /my/media:/mnt/media subsync /mnt/media/video.mp4 [options...]
```