### PR TITLE
Switch to using required inputs for better control

### DIFF
--- a/subsync/media.py
+++ b/subsync/media.py
@@ -85,7 +85,7 @@ class Media:
     def mfcc(self, duration=60 * 15, seek=True):
         transcode = Transcode(self.filepath, duration=duration, seek=seek)
         self.offset = transcode.start
-        print("Transcoding...")
+        print(f"Transcoding audio from {self.filepath}...")
         transcode.run()
         y, sr = librosa.load(transcode.output, sr=Media.FREQ)
         print("Analysing...")
@@ -191,6 +191,7 @@ class Subtitle:
         print("Fitting...")
         self.__sync_all_rec(self.subs, pred)
         self.clean()
+        print(f"Saving {self.path}")
         self.subs.save(self.path, encoding="utf-8")
 
     def __sync_all_rec(self, subs, pred, margin=16):


### PR DESCRIPTION
Switching to required inputs for both `--media` and `--srt` to allow for greater control when specifying which video + subtitle file to synchronize.  This allows for the srt file to be located in a different directory than the video.

```bash
subsync --media path/to/video.mp4 --srt other/path/to/video.en.srt
```