### PR TITLE
feat!: Switch to using required inputs for better control

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,6 +11,8 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Subsync
 
 Docker repository: https://hub.docker.com/r/rapportus/subsync
+* [CHANGELOG](/CHANGELOG.md) (tracks release history for Docker image above ONLY. Not associated with pypi)
 
 **Synchronize your subtitles using machine learning**
 

--- a/subsync/main.py
+++ b/subsync/main.py
@@ -2,6 +2,8 @@ import argparse
 import os
 
 from .log import logger, init_logger
+from .media import Media
+from .net import NeuralNet
 from .version import __version__
 
 
@@ -87,17 +89,12 @@ def run():
     if args.logfile:
         init_logger(args.logfile)
 
-    from .media import Media
-
     if not os.path.exists(args.media):
         raise ValueError(f"{args.media} does not exist")
     if not os.path.exists(args.srt):
         raise ValueError(f"{args.srt} does not exist")
 
     media = Media(filepath=args.media, subtitles=[args.srt])
-
-    from .net import NeuralNet
-
     model = NeuralNet()
 
     if args.recursive:


### PR DESCRIPTION
_Using this PR to trigger new release through ci/cd for the first time. Breaking changes originated in https://github.com/Rapportus/subsync/pull/4_

Switching to required inputs for both `--media` and `--srt` to allow for greater control when specifying which video + subtitle file to synchronize.  This allows for the srt file to be located in a different directory than the video.

```bash
subsync --media path/to/video.mp4 --srt other/path/to/video.en.srt
```